### PR TITLE
Ruleset update and autofix fixes

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -77,7 +77,6 @@ rules:
     - 1
     - include: true
   mixins-before-declarations: 1
-  no-attribute-selectors: 1
   no-mergeable-selectors: 1
   no-trailing-zero: 1
   no-vendor-prefixes: 1

--- a/autofix/rules/empty-line-between-blocks.js
+++ b/autofix/rules/empty-line-between-blocks.js
@@ -7,7 +7,20 @@ function emptyLineBetweenBlocks(tree) {
     if (node.is('ruleset') && index > 0) {
       const prev = parent.get(index - 1);
 
+      // fix only if any of leading elements is anything than space
+      let leadingIndex = index - 1;
+      while (true) {
+        if (!parent.get(leadingIndex).is('space')) {
+          break;
+        }
+
+        if (--leadingIndex < 0) {
+          return;
+        }
+      }
+
       if (prev && prev.is('space') && !/(\n){2}/.test(prev.content)) {
+        console.log(parent);
         prev.content = prev.content.replace('\n', '\n\n');
 
         fixCount++;

--- a/autofix/rules/empty-line-between-blocks.js
+++ b/autofix/rules/empty-line-between-blocks.js
@@ -7,7 +7,7 @@ function emptyLineBetweenBlocks(tree) {
     if (node.is('ruleset') && index > 0) {
       const prev = parent.get(index - 1);
 
-      // fix only if any of leading elements is anything than space
+      // do not fix if all of leading siblings are spaces
       const leadingSiblings = parent.content.slice(0, index);
       if (leadingSiblings.length > 0 && leadingSiblings.every(sibling => sibling.is('space'))) {
         return;

--- a/autofix/rules/empty-line-between-blocks.js
+++ b/autofix/rules/empty-line-between-blocks.js
@@ -20,7 +20,6 @@ function emptyLineBetweenBlocks(tree) {
       }
 
       if (prev && prev.is('space') && !/(\n){2}/.test(prev.content)) {
-        console.log(parent);
         prev.content = prev.content.replace('\n', '\n\n');
 
         fixCount++;

--- a/autofix/rules/empty-line-between-blocks.js
+++ b/autofix/rules/empty-line-between-blocks.js
@@ -8,15 +8,9 @@ function emptyLineBetweenBlocks(tree) {
       const prev = parent.get(index - 1);
 
       // fix only if any of leading elements is anything than space
-      let leadingIndex = index - 1;
-      while (true) {
-        if (!parent.get(leadingIndex).is('space')) {
-          break;
-        }
-
-        if (--leadingIndex < 0) {
-          return;
-        }
+      const leadingSiblings = parent.content.slice(0, index);
+      if (leadingSiblings.length > 0 && leadingSiblings.every(sibling => sibling.is('space'))) {
+        return;
       }
 
       if (prev && prev.is('space') && !/(\n){2}/.test(prev.content)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-lint-config-airhelp",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "AirHelp SASSLint shareable config",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
* Removed `no-attribute-selectors` rule from config
* Fixed autofix for `empty-line-between-blocks` rule