### PR TITLE
Initial Release proposition

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+autofix/
+test/

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -46,6 +46,7 @@ rules:
   leading-zero:
     - 2
     - include: true
+  mixins-before-declarations: 2
   mixin-name-format:
     - 2
     - convention: hyphenatedlowercase
@@ -81,5 +82,4 @@ rules:
     - allow-leading-underscore: false
   zero-unit: 2
 
-  mixins-before-declarations: 1
   no-vendor-prefixes: 1

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -2,82 +2,84 @@ options:
   cache-config: false
   merge-default-rules: false
 rules:
-  # target: error
+  border-zero:
+    - 2
+    - convention: '0'
   brace-style:
-    - 1
+    - 2
     - style: 1tbs
     - allow-single-line: false
   class-name-format:
-    - 1
+    - 2
     - convention: hyphenatedbem
     - allow-leading-underscore: false
-  declarations-before-nesting: 1
+  clean-import-paths:
+    - 2
+    - leading-underscore: false
+    - filename-extension: false
+  declarations-before-nesting: 2
   empty-line-between-blocks:
-    - 1
+    - 2
     - include: true
+  extends-before-declarations: 2
+  extends-before-mixins: 2
   final-newline:
-    - 1
+    - 2
     - include: true
   function-name-format:
-    - 1
+    - 2
     - convention: hyphenatedlowercase
     - allow-leading-underscore: false
   hex-length:
-    - 1
+    - 2
     - style: short
   hex-notation:
-    - 1
+    - 2
     - style: uppercase
   id-name-format:
-    - 1
+    - 2
     - convention: hyphenatedlowercase
     - allow-leading-underscore: false
   indentation:
-    - 1
+    - 2
     - size: 2
-  mixin-name-format:
-    - 1
-    - convention: hyphenatedlowercase
-    - allow-leading-underscore: false
-  no-duplicate-properties: 1
-  no-empty-rulesets: 1
-  no-invalid-hex: 1
-  no-misspelled-properties: 1
-  no-trailing-whitespace: 1
-  one-declaration-per-line : 1
-  quotes:
-    - 1
-    - style: single
-  space-after-colon: 1
-  space-after-comma: 1
-  space-around-operator: 1
-  space-before-bang: 1
-  space-before-brace: 1
-  space-before-colon: 1
-  space-between-parens: 1
-  trailing-semicolon: 1
-  url-quotes: 1
-  variable-name-format:
-    - 1
-    - convention: hyphenatedlowercase
-    - allow-leading-underscore: false
-  zero-unit: 1
-
-  # target: warning
-  border-zero:
-    - 1
-    - convention: '0'
-  clean-import-paths:
-    - 1
-    - leading-underscore: false
-    - filename-extension: false
-  extends-before-declarations: 1
-  extends-before-mixins: 1
   leading-zero:
-    - 1
+    - 2
     - include: true
+  mixin-name-format:
+    - 2
+    - convention: hyphenatedlowercase
+    - allow-leading-underscore: false
+  no-duplicate-properties: 2
+  no-empty-rulesets: 2
+  no-invalid-hex: 2
+  no-mergeable-selectors: 2
+  no-misspelled-properties:
+      - 2
+      - extra-properties:
+        - overflow-scrolling
+        - touch-callout
+  no-trailing-whitespace: 2
+  no-trailing-zero: 2
+  one-declaration-per-line : 2
+  quotes:
+    - 2
+    - style: single
+  shorthand-values: 2
+  space-after-colon: 2
+  space-after-comma: 2
+  space-around-operator: 2
+  space-before-bang: 2
+  space-before-brace: 2
+  space-before-colon: 2
+  space-between-parens: 2
+  trailing-semicolon: 2
+  url-quotes: 2
+  variable-name-format:
+    - 2
+    - convention: hyphenatedlowercase
+    - allow-leading-underscore: false
+  zero-unit: 2
+
   mixins-before-declarations: 1
-  no-mergeable-selectors: 1
-  no-trailing-zero: 1
   no-vendor-prefixes: 1
-  shorthand-values: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
+### 1.1.4 (2/03/17)
 
-## v1.1.0
-- fix typo in config file name ([c677322](https://github.com/AirHelp/sass-lint-config-airhelp/commit/c677322135a0976ee83c4888f26d6e3f356e2ad1))
+Major update
 
-## v1.0.0
-- add initial config rules proposal ([7d447f5](https://github.com/AirHelp/sass-lint-config-airhelp/commit/7d447f5e52f95590b314c87bb088c2965a8a1d63))
-- add empty changelog ([40e7092](https://github.com/AirHelp/sass-lint-config-airhelp/commit/40e70921817e89fc4b328a077e89749a36f8b250))
-- add .gitignore ([539c043](https://github.com/AirHelp/sass-lint-config-airhelp/commit/539c0430aab97cce21ab8fc75fc47bc7c0936b52))
-- create package.json for the project ([0a30b19](https://github.com/AirHelp/sass-lint-config-airhelp/commit/0a30b199586b6481cb8309d514f62d5ddb533431))
+- :tada: Initial release.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # sass-lint-config-airhelp
 npm package with AirHelp SASSLint shareable config
-##Usage
+
+## Usage
 1. Install `sass-lint`
 ```
   npm install --save-dev sass-lint
@@ -11,20 +12,7 @@ npm package with AirHelp SASSLint shareable config
 options:
   config-file: node_modules/sass-lint-config-airhelp/.sass-lint.yml
 ```
-##Contribution
-Please introduce changes in separate PRs.
 
-This package is using [simple-git-changelog](https://github.com/ianhenderson/simple-git-changelog) for creating changelog. Please use following prefixes for all commits that are supposed to be part of changelog:
-* `changelog`
-* `fix`
-* `docs`
-* `chore`
-* `feat`
-* `feature`
-* `refactor`
-* `update`
+## Changelog
 
-for example:
-```
-git commit -m "fix: lorem ispum dolor"
-```
+Please refer to [Changelog](CHANGELOG.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-lint-config-airhelp",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "AirHelp SASSLint shareable config",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/package.json
+++ b/package.json
@@ -25,12 +25,9 @@
     "url": "https://github.com/AirHelp/sass-lint-config-airhelp/issues"
   },
   "homepage": "https://github.com/AirHelp/sass-lint-config-airhelp#readme",
-  "dependencies": {
+  "devDependencies": {
     "gonzales-pe": "^4.0.3",
     "walk-sync": "^0.3.1",
     "yargs": "^6.6.0"
-  },
-  "devDependencies": {
-    "simple-git-changelog": "^1.5.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -77,8 +77,8 @@ graceful-fs@^4.1.2:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
 hosted-git-info@^2.1.4:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.1.5.tgz#0ba81d90da2e25ab34a332e6ec77936e1598118b"
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.2.0.tgz#7a0d097863d886c0fabbdcd37bf1758d8becf8a5"
 
 invert-kv@^1.0.0:
   version "1.0.0"
@@ -219,10 +219,6 @@ require-main-filename@^1.0.1:
 set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
-
-simple-git-changelog@^1.5.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/simple-git-changelog/-/simple-git-changelog-1.7.0.tgz#15ee3fd1f2a450efd65cbf57ce28a1af4e230ca2"
 
 spdx-correct@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
This PR makes this repository ready for being an `npm` package.

Changes:

* Removed `autofix` directory from npm install
* Markes all `autofix` dependencies as `devDependencies`
* Changed most rules to **errors**
  * `no-vendor-prefixes` stays as **warning** for now
* Removed `simple-git-changelog` (it's not very handy), created manual changelog and refered to it